### PR TITLE
Removed deprecated project property "PackageTargetFallback".

### DIFF
--- a/VoronoiSpeedTest/VoronoiSpeedTest.csproj
+++ b/VoronoiSpeedTest/VoronoiSpeedTest.csproj
@@ -6,7 +6,6 @@
     <OutputType>Exe</OutputType>
     <PackageId>VoronoiSpeedTest</PackageId>
     <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
From the discussion in [this issue](https://github.com/Azure/azure-event-hubs-dotnet/issues/267) from the Azure repo, for SDK 2.0, the `PackageTargetFallback` project property is not needed and deprecated. Just deleting it solves the issue.

Ran the project after the change in OSX and it works (both in VS Code and Visual Studio for Mac). Did not test on Windows.

Fixes #1. 